### PR TITLE
Update style.css for vertical resizing

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -282,3 +282,14 @@ md-input-container.no-space .md-errors-spacer {
 ._md-nav-button.md-active {
     color: white !important;
 }
+
+@media all and (max-height: 670px) {
+    img.left {
+        height: 0;
+        width: 0;
+    }
+    img.right {
+        height: 0;
+        width: 0;
+    }
+}


### PR DESCRIPTION
Prevent image overlap for vertical resizing of webpage. Currently at view heights below 670px, image.left and image.right elements overlap with main content on the page.