### PR TITLE
Add custom send time per recipient

### DIFF
--- a/app/models/recipient.js
+++ b/app/models/recipient.js
@@ -20,7 +20,8 @@ const RecipientSchema = new Schema({
     subscriptions: [{
         type: String,
         enum: strings.animalTypes // TODO: Move to constant definition
-    }]
+    }],
+    sendHour: { type: Number, default: 8, min: 0, max: 23 }
 }, {
     timestamps: true
 });

--- a/app/routes/catbot.routes.js
+++ b/app/routes/catbot.routes.js
@@ -33,12 +33,15 @@ router.get('/daily', async(req, res) => {
     const todayEnd = new Date();
     todayEnd.setHours(23, 59, 59, 999);
 
+    const hour = req.query.hour !== undefined ? parseInt(req.query.hour) : null;
+
     let getFactAndRecipients = async animalType => {
+        const recipientFilter = { subscriptions: animalType };
+        if (hour !== null) recipientFilter.sendHour = hour;
+
         let { recipients, overrideFact, fact } = await Promise.props({
 
-            recipients: Recipient.find({
-                subscriptions: animalType
-            }, {
+            recipients: Recipient.find(recipientFilter, {
                 number: 1
             }),
 

--- a/app/routes/recipient.routes.js
+++ b/app/routes/recipient.routes.js
@@ -129,11 +129,11 @@ router.patch('/:recipientId', isAuthenticated, async(req, res) => {
     // TODO: only allow to edit recipient if user isAdmin or is addedBy them
 
     try {
+        const update = { name: req.body.name, number: req.body.number };
+        if (req.body.sendHour !== undefined) update.sendHour = req.body.sendHour;
+
         const recipient = await Recipient.update({ _id: req.params.recipientId }, {
-            $set: {
-                name: req.body.name,
-                number: req.body.number
-            }
+            $set: update
         });
 
         return res.status(200).json(recipient);

--- a/public/js/directives/recipients-list.js
+++ b/public/js/directives/recipients-list.js
@@ -18,8 +18,16 @@ app.directive('recipients', function() {
             
             $scope.$mdMedia = $mdMedia;
             $scope.selected = [];
-            
+
             $scope.animals = animalProvider;
+
+            $scope.formatHour = function(h) {
+                h = (h === undefined || h === null) ? 8 : h;
+                if (h === 0) return '12 AM';
+                if (h < 12) return h + ' AM';
+                if (h === 12) return '12 PM';
+                return (h - 12) + ' PM';
+            };
             
             $scope.openConversation = function(event, recipient) {
                 $mdDialog.show({
@@ -36,10 +44,11 @@ app.directive('recipients', function() {
             $scope.editRecipient = function(event, recipient) {
                 $mdDialog.show({
                     controller: ['$scope', '$mdDialog', function($scope, $mdDialog) {
-                        
-                        $scope.recipient = recipient;
+
+                        $scope.recipient = angular.copy(recipient);
+                        $scope.hours = Array.from({length: 24}, (_, i) => i);
                         $scope.cancel = $mdDialog.hide;
-                        
+
                         $scope.save = function() {
                             ApiService.editRecipient($scope.recipient).then(function(recipient) {
                                 $mdDialog.hide(recipient);

--- a/public/views/directives/recipients-list.html
+++ b/public/views/directives/recipients-list.html
@@ -28,6 +28,7 @@
 				<th md-column><span>Name</span></th>
 				<th md-column ng-if="options.addedBy"><span>Added By</span></th>
 				<th md-column ng-show="options.dateAdded && $mdMedia('gt-xs')">Date Added</th>
+				<th md-column ng-show="$mdMedia('gt-xs')">Send Time</th>
 				<th md-column>Subscriptions</th>
 				<th md-column md-numeric><span>Phone Number</span></th>
 			</tr>
@@ -46,6 +47,7 @@
 				<td md-cell>{{recipient.name || 'No name'}}</td>
 				<td md-cell ng-if="options.addedBy">{{recipient.addedBy.name.first}} {{recipient.addedBy.name.last}}</td>
 				<td md-cell ng-show="options.dateAdded && $mdMedia('gt-xs')">{{recipient.updatedAt | date:'MMMM d, yyyy'}}</td>
+				<td md-cell ng-show="$mdMedia('gt-xs')">{{formatHour(recipient.sendHour)}}</td>
 				<td md-cell>
 					<md-button
 						class="md-icon-button subscription-icon"

--- a/public/views/partials/edit-recipient.html
+++ b/public/views/partials/edit-recipient.html
@@ -13,6 +13,15 @@
             <label>Phone number</label>
             <input ng-model="recipient.number">
         </md-input-container>
+
+        <md-input-container class="no-space">
+            <label>Daily send time</label>
+            <md-select ng-model="recipient.sendHour">
+                <md-option ng-repeat="h in hours" ng-value="h">
+                    {{h === 0 ? '12:00 AM' : h < 12 ? h + ':00 AM' : h === 12 ? '12:00 PM' : (h - 12) + ':00 PM'}}
+                </md-option>
+            </md-select>
+        </md-input-container>
     </md-dialog-content>
     
     <md-dialog-actions>


### PR DESCRIPTION
Allow users to set a preferred daily send hour (0–23) on each recipient. The /catbot/daily endpoint accepts an optional ?hour= param to filter recipients by their preferred time. Defaults to 8 AM.