### PR TITLE
feat: show toast alert before redirecting unauthenticated users to si…

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -137,13 +137,31 @@ app.run(['$rootScope', '$state', '$window', '$location', '$mdToast', 'ApiService
                         $rootScope.authenticatedUser = false;
 
                         if (toState.data.restricted) {
-                            window.location.href = '/auth/google';
+                            $mdToast.show(
+                                $mdToast.simple()
+                                    .textContent('Please sign in first 🔒')
+                                    .position('bottom right')
+                                    .hideDelay(3000)
+                            ).then(function() {
+                                window.location.href = '/auth/google';
+                            });
+                            setTimeout(function() {
+                                window.location.href = '/auth/google';
+                            }, 3200);
                         }
                     });
             } else if (!$rootScope.authenticatedUser && toState.data.restricted) {
+                $mdToast.show(
+                    $mdToast.simple()
+                        .textContent('Please sign in first 🔒')
+                        .position('bottom right')
+                        .hideDelay(3000)
+                ).then(function() {
+                    window.location.href = '/auth/google';
+                });
                 setTimeout(function() {
                     window.location.href = '/auth/google';
-                }, 100);
+                }, 3200);
             }
         });
 


### PR DESCRIPTION
#164 issue 

## Problem
Unauthenticated users navigating directly to restricted routes (e.g. `/cat/recipients` or `/cat/console`) were silently redirected to Google OAuth with no explanation, resulting in confusing UX.

## Solution
Added an Angular Material toast notification:

> Please sign in first 
The toast is displayed before redirecting users to Google OAuth.
This covers both cases where the auth guard triggers:

* Cold load: auth check returns `401`
* Warm load: `authenticatedUser` is already `false`

## Changes
* Updated `public/js/app.js`
* Replaced silent redirects with a toast notification followed by a delayed redirect to `/auth/google`

##  Testing
1. Open the app while signed out
2. Navigate to `/#/cat/recipients` or `/#/cat/console`

Expected:

* Toast notification appears
* User is redirected to Google sign-in after a short delay

Fixes #164
