### PR TITLE
fix: prevent failed IFTTT deliveries from being saved as successful s…

### DIFF
--- a/app/services/ifttt.service.js
+++ b/app/services/ifttt.service.js
@@ -17,18 +17,19 @@ module.exports = {
                     'value2': data.message
                 }
             });
+
+            const message = new Message({
+                text: data.message,
+                number: data.number,
+                type: 'outgoing'
+            });
+
+            await message.save();
+            console.log(`Message sent to ${data.number}: ${data.message}`);
         } catch (err) {
-            console.error(err);
+            console.error(`Failed to send message to ${data.number}:`, err);
+            throw err;
         }
-
-        const message = new Message({
-            text: data.message,
-            number: data.number,
-            type: 'outgoing'
-        });
-
-        await message.save(message);
-        console.log(`Message sent to ${data.number}: ${data.message}`);
     },
     async sendBatchMessages(data) {
         const promises = data.map(message => {


### PR DESCRIPTION
#198 

Problem:
If an IFTTT request fails (for example due to an invalid API key, missing applet, or network issue), the error was logged but message processing continued. As a result, messages were saved to the database as if they were successfully sent even when delivery never occurred.

Solution:
- Moved message.save() inside the try block so it only runs after a confirmed successful IFTTT request
- Re-throw errors in the catch block so callers are aware of failures
- Improved error log to include the recipient phone number for easier diagnosis
- Fixed redundant argument passed to message.save(message) -> message.save()

Benefits:
- Prevents incorrect message records
- Improves reliability of delivery tracking
- Makes IFTTT failures easier to diagnose